### PR TITLE
Add transactions validation, Fix the challenge script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -374,9 +374,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bb_rs"
@@ -425,7 +425,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.102",
+ "syn 2.0.103",
  "which",
 ]
 
@@ -615,9 +615,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -705,7 +705,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -792,7 +792,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml 0.8.23",
- "winnow 0.7.10",
+ "winnow 0.7.11",
  "yaml-rust2",
 ]
 
@@ -958,7 +958,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -969,7 +969,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1022,7 +1022,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1033,6 +1033,12 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -1268,7 +1274,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1851,9 +1857,9 @@ checksum = "82903360c009b816f5ab72a9b68158c27c301ee2c3f20655b55c5e589e7d3bb7"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "libloading"
@@ -1862,7 +1868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1901,9 +1907,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -1954,7 +1960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -2314,6 +2320,7 @@ name = "op-rand-transaction-builder"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "eyre",
  "miniscript",
  "op-rand-types",
  "thiserror 2.0.12",
@@ -2350,7 +2357,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2447,9 +2454,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -2458,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2468,24 +2475,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -2560,12 +2566,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2693,11 +2699,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2731,9 +2757,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.19"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2749,12 +2775,10 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls-pki-types",
@@ -2830,7 +2854,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.102",
+ "syn 2.0.103",
  "walkdir",
 ]
 
@@ -2904,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -3031,6 +3055,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,7 +3162,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3164,15 +3200,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3182,14 +3219,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3249,12 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "small-ord-set"
@@ -3353,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3379,7 +3413,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3451,7 +3485,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3462,17 +3496,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -3551,7 +3584,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3643,7 +3676,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.10",
+ "winnow 0.7.11",
 ]
 
 [[package]]
@@ -3710,7 +3743,7 @@ checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3906,9 +3939,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -3941,7 +3974,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -3976,7 +4009,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4074,7 +4107,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4085,14 +4118,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
@@ -4159,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -4280,9 +4313,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -4333,7 +4366,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -4354,7 +4387,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4374,7 +4407,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -4395,7 +4428,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4428,5 +4461,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]

--- a/README.md
+++ b/README.md
@@ -137,6 +137,279 @@ op-rand-cli try-spend \
   --challenger  # or --acceptor depending on who won
 ```
 
+## 🧩 SDK Usage
+
+For developers who want to integrate OP_RAND into their applications, you can use the SDK crates directly instead of the CLI.
+
+### Basic SDK Flow
+
+> ⚠️ **Security Critical**: Always verify proofs from the counterparty before proceeding with any transaction. Skipping verification can lead to loss of funds.
+
+> 📝 **Note**: The following is a simplified example for educational purposes. It omits many practical aspects like data serialization/sharing between parties, proper UTXO management, network communication, comprehensive error handling, and transaction broadcasting. This code is **not intended to compile** as-is and serves only to illustrate the core cryptographic and transaction flow.
+
+```rust
+use bitcoin::{Amount, OutPoint, PublicKey, WPubkeyHash, secp256k1::SecretKey};
+use bitcoin::hashes::{Hash, sha256};
+use bitcoin::secp256k1::{Message, rand::thread_rng};
+use bitcoin::absolute::{Height, LockTime};
+use op_rand_types::{Commitments, FirstRankCommitment, ThirdRankCommitment};
+use op_rand_prover::{BarretenbergProver, OpRandProver, OpRandProof};
+use op_rand_transaction_builder::{TransactionBuilder, validate_deposit_transaction, validate_challenge_psbt};
+use std::str::FromStr;
+
+// 1. Create Challenge (Challenger)
+let challenger_secret = SecretKey::new(&mut thread_rng());
+let secp = bitcoin::secp256k1::Secp256k1::new();
+let challenger_pubkey = challenger_secret.public_key(&secp);
+
+// Generate commitments
+let commitments = Commitments::generate(&secp, &mut thread_rng())?;
+let first_rank_commitments = commitments.first_rank_commitments();
+let third_rank_commitments = commitments.third_rank_commitments();
+
+// Pick a random first rank commitment
+let selected_first_rank_commitment = commitments
+    .pick_random_first_rank_commitment(&mut thread_rng())?;
+
+// Create prover and setup circuits
+let prover = BarretenbergProver::default();
+prover.setup_challenger_circuit()?;
+
+// Generate challenger proof
+let challenger_pubkey_hash = PublicKey::new(challenger_pubkey).wpubkey_hash();
+let proof = prover.generate_challenger_proof(
+    first_rank_commitments.clone(),
+    third_rank_commitments.clone(),
+    &challenger_pubkey,
+    challenger_pubkey_hash.to_byte_array(),
+)?;
+
+// Build deposit transaction
+let transaction_builder = TransactionBuilder::from(challenger_secret);
+let prevouts = vec![(outpoint, Amount::from_sat(150_000))]; // your UTXOs
+let deposit_tx = transaction_builder.build_deposit_transaction(
+    selected_first_rank_commitment.clone(),
+    prevouts,
+    Amount::from_sat(100_000),
+    None,
+    None,
+)?;
+
+// 2. Accept Challenge (Acceptor)
+let acceptor_secret = SecretKey::new(&mut thread_rng());
+let acceptor_pubkey = acceptor_secret.public_key(&secp);
+let selected_commitment_index = 0; // Acceptor's choice
+let selected_commitment = third_rank_commitments[selected_commitment_index].clone();
+
+// IMPORTANT: Verify challenger's proof before proceeding
+prover.verify_challenger_proof(
+    third_rank_commitments.clone(),
+    &challenger_pubkey,
+    challenger_pubkey_hash.to_byte_array(),
+    &proof,
+)?;
+
+// Validate the challenger's deposit transaction
+validate_deposit_transaction(&deposit_tx, &challenger_pubkey_hash, 0)?;
+
+// Setup acceptor circuit and generate proof
+prover.setup_acceptor_circuit()?;
+
+// Create correct signature for acceptor proof
+// 1. Combine acceptor's public key with selected commitment
+let pk_combined = acceptor_pubkey.combine(&selected_commitment.inner())?;
+let acceptor_pubkey_hash = PublicKey::new(pk_combined).wpubkey_hash()?;
+
+// 2. Create message by double-hashing the combined pubkey hash
+let message = Message::from_digest(
+    sha256::Hash::hash(acceptor_pubkey_hash.as_byte_array()).to_byte_array()
+);
+
+// 3. Sign the message with acceptor's private key
+let acceptor_signature = secp.sign_ecdsa(&message, &acceptor_secret);
+
+let acceptor_proof = prover.generate_acceptor_proof(
+    &acceptor_pubkey,
+    &acceptor_signature,
+    acceptor_pubkey_hash.to_byte_array(),
+    third_rank_commitments.clone(),
+)?;
+
+// Build challenge transaction (PSBT)
+let acceptor_tx_builder = TransactionBuilder::from(acceptor_secret);
+let acceptor_prevouts = vec![(outpoint, Amount::from_sat(150_000))]; // Your utxos
+let challenge_psbt = acceptor_tx_builder.build_challenge_tx(
+    &PublicKey::from(challenger_pubkey),
+    OutPoint::new(deposit_tx.compute_txid(), 0),
+    selected_commitment,
+    bitcoin::absolute::LockTime::Blocks(bitcoin::absolute::Height::from_consensus(144)?),
+    Amount::from_sat(100_000),
+    acceptor_prevouts,
+    None,
+    None,
+)?;
+
+// 3. Complete Challenge (Challenger)
+// Verify acceptor proof first
+prover.verify_acceptor_proof(
+    acceptor_pubkey_hash.to_byte_array(),
+    third_rank_commitments.clone(),
+    &acceptor_proof,
+)?;
+
+// IMPORTANT: Validate the challenge PSBT before proceeding
+validate_challenge_psbt(
+    &challenge_psbt,
+    acceptor_pubkey_hash,
+    PublicKey::from(challenger_pubkey),
+    LockTime::Blocks(Height::from_consensus(144)?),
+    0, // output index
+)?;
+
+// Complete the challenge transaction
+let completed_tx = transaction_builder.complete_challenge_tx(
+    challenge_psbt,
+    Amount::from_sat(100_000),
+    0, // deposit input index
+    selected_first_rank_commitment.clone(),
+)?;
+
+// 4. Spend Winnings (Winner)
+// The winner can use sweep methods to claim funds
+let sweep_tx = transaction_builder.sweep_challenge_output_acceptor(
+    &completed_tx,
+    &PublicKey::from(challenger_pubkey),
+    None, // use acceptor's pubkey
+    bitcoin::absolute::LockTime::Blocks(bitcoin::absolute::Height::from_consensus(144)?),
+    Amount::from_sat(1000), // fee
+)?;
+```
+
+### SDK Building Blocks
+
+The SDK is built on three main crates that provide different levels of abstractions:
+
+#### Core Crate APIs
+
+- **`op_rand_types`** - Core data structures
+  - `Commitments` - Generate and manage first/third rank commitments
+  - `FirstRankCommitment` - Private commitments for challengers
+  - `ThirdRankCommitment` - Public commitments for acceptors
+- **`op_rand_prover`** - ZK proof system
+  - `BarretenbergProver` - Main prover implementation
+  - `OpRandProof` - Proof container with verification key
+  - `OpRandProver` trait - Common interface for proof operations
+- **`op_rand_transaction_builder`** - Bitcoin transaction utilities
+  - `TransactionBuilder` - Build deposit, challenge, and sweep transactions
+  - `TransactionSigner` - Handle transaction signing with commitment tweaks
+
+#### Mid-Level Components
+
+- **Circuit Setup** - `setup_challenger_circuit()` and `setup_acceptor_circuit()`
+- **Proof Generation** - `generate_challenger_proof()` and `generate_acceptor_proof()`
+- **Proof Verification** - `verify_challenger_proof()` and `verify_acceptor_proof()`
+- **Transaction Flow** - `build_deposit_transaction()`, `build_challenge_tx()`, `complete_challenge_tx()`
+
+#### Low-Level Primitives
+
+- **Commitment Operations** - `combine()`, `add_tweak()`, `inner()` methods
+- **Secp256k1 Integration** - Direct access to Bitcoin cryptographic primitives
+- **PSBT Handling** - Partially Signed Bitcoin Transaction support
+- **Script Generation** - P2WPKH and P2WSH script creation
+
+### Error Handling
+
+The SDK provides comprehensive error types:
+
+```rust
+use op_rand_prover::ProverError;
+use op_rand_transaction_builder::TransactionError;
+use bitcoin::secp256k1::Error as Secp256k1Error;
+
+// Prover errors
+match prover.generate_challenger_proof(/* ... */) {
+    Ok(proof) => {
+        // Success case
+    }
+    Err(ProverError::SetupError(msg)) => {
+        eprintln!("Circuit setup failed: {}", msg);
+    }
+    Err(ProverError::ProofGenerationError(msg)) => {
+        eprintln!("Proof generation failed: {}", msg);
+    }
+    Err(ProverError::InvalidProof) => {
+        eprintln!("Proof verification failed");
+    }
+    Err(e) => {
+        eprintln!("Prover error: {}", e);
+    }
+}
+
+// Transaction builder errors
+match transaction_builder.build_deposit_transaction(/* ... */) {
+    Ok(tx) => {
+        // Success case
+    }
+    Err(TransactionError::Secp256k1(secp_err)) => {
+        eprintln!("Cryptographic error: {}", secp_err);
+    }
+    Err(TransactionError::InputIndexOutOfBounds) => {
+        eprintln!("Invalid input index");
+    }
+    Err(TransactionError::ExtractTransactionFailed) => {
+        eprintln!("Failed to extract transaction from PSBT");
+    }
+    Err(e) => {
+        eprintln!("Transaction error: {}", e);
+    }
+}
+```
+
+## 🚧 Areas for Improvement
+
+The current implementation has several areas that could be enhanced for better developer experience and production readiness:
+
+### SDK & Developer Experience
+
+- **Simplified High-Level API**: The current flow requires understanding of multiple low-level concepts. A unified `OpRandClient` could abstract away the complexity
+- **Better Error Messages**: More descriptive error messages with suggested fixes
+- **Async/Await Support**: Current implementation is synchronous; async support would improve integration
+- **Builder Pattern Improvements**: More fluent APIs with better validation and defaults
+- **Type Safety**: Stronger type system to prevent runtime errors (e.g., using phantom types for protocol states)
+
+### Documentation & Examples
+
+- **Interactive Tutorials**: Step-by-step guides for common use cases
+- **API Documentation**: Comprehensive rustdoc with examples for all public APIs
+- **Integration Examples**: Real-world examples for web apps, mobile apps, and server applications
+- **Protocol Visualization**: Interactive diagrams explaining the cryptographic flow
+- **Video Tutorials**: Visual explanations of the protocol and implementation
+
+### Performance & Scalability
+
+- **Proof Generation Optimization**: Faster ZK proof generation
+- **Memory Optimization**: Reduce memory footprint for resource-constrained environments
+- **Batch Operations**: Support for processing multiple challenges efficiently
+
+### Security & Robustness
+
+- **Public signals verification**: Extract public signals from the proof and verify they are correct
+- **Audit Trail**: Better logging and monitoring for production deployments
+- **Input Validation**: Comprehensive validation of all user inputs and external data
+
+### Protocol Enhancements
+
+- **Multi-Party Support**: Extend beyond two-party challenges
+- **Configurable Outcomes**: Support for non-50/50 probability distributions
+- **Lightning Network Integration**: Support for off-chain OP_RAND operations
+
+### Testing & Quality Assurance
+
+- **Comprehensive Test Suite**: Unit, integration, and end-to-end tests
+- **Property-Based Testing**: Automated testing of cryptographic properties
+- **Fuzzing**: Automated discovery of edge cases and potential vulnerabilities
+- **Benchmark Suite**: Performance regression testing
+
 ## 📚 Documentation
 
 - **[CLI Reference](apps/cli/README.md)** - Complete command-line interface documentation

--- a/apps/cli/src/actions/accept_challenge/mod.rs
+++ b/apps/cli/src/actions/accept_challenge/mod.rs
@@ -6,11 +6,11 @@ use crate::{
 };
 use base64::{Engine as _, engine::general_purpose};
 use bitcoin::{
-    Address, Amount, CompressedPublicKey, OutPoint, Transaction, Txid,
+    Address, Amount, CompressedPublicKey, OutPoint, PublicKey, Transaction, Txid,
     absolute::{Height, LockTime},
     consensus::encode::deserialize_hex,
-    hashes::{Hash, ripemd160, sha256},
-    secp256k1::{Message, PublicKey, SecretKey},
+    hashes::{Hash, sha256},
+    secp256k1::{Message, SecretKey},
 };
 use clap::Args;
 use color_eyre::eyre;
@@ -111,7 +111,7 @@ pub async fn run(
 
     prover.verify_challenger_proof(
         commitments.clone(),
-        &challenger_pubkey,
+        &challenger_pubkey.inner,
         challenger_pubkey_hash,
         &proof_data,
     )?;
@@ -210,12 +210,10 @@ pub async fn run(
     )?;
 
     let pk_combined = public_key.inner.combine(&selected_commitment.inner())?;
-
-    let sha256_hash = sha256::Hash::hash(&pk_combined.serialize());
-    let ripemd160_hash = ripemd160::Hash::hash(sha256_hash.as_byte_array());
+    let pubkey_hash = PublicKey::new(pk_combined).wpubkey_hash()?;
 
     let message =
-        Message::from_digest(sha256::Hash::hash(ripemd160_hash.as_byte_array()).to_byte_array());
+        Message::from_digest(sha256::Hash::hash(pubkey_hash.as_byte_array()).to_byte_array());
     let sk = SecretKey::from_slice(&private_key.to_bytes())?;
 
     let sig = secp.sign_ecdsa(&message, &sk);
@@ -233,7 +231,7 @@ pub async fn run(
     let proof = prover.generate_acceptor_proof(
         &public_key.inner,
         &sig,
-        ripemd160_hash.to_byte_array(),
+        pubkey_hash.to_byte_array(),
         commitments,
     )?;
     pb.finish_with_message("Acceptor proof generated");
@@ -248,7 +246,7 @@ pub async fn run(
         id: challenge_data.id.clone(),
         proof: hex::encode(proof.proof()),
         vk: hex::encode(proof.vk()),
-        acceptor_pubkey_hash: hex::encode(ripemd160_hash),
+        acceptor_pubkey_hash: hex::encode(pubkey_hash.to_byte_array()),
         third_rank_commitments: challenge_data.third_rank_commitments,
         psbt: general_purpose::STANDARD.encode(psbt.serialize()),
     };

--- a/apps/cli/src/actions/accept_challenge/mod.rs
+++ b/apps/cli/src/actions/accept_challenge/mod.rs
@@ -6,8 +6,9 @@ use crate::{
 };
 use base64::{Engine as _, engine::general_purpose};
 use bitcoin::{
-    Address, Amount, CompressedPublicKey, OutPoint, Txid,
+    Address, Amount, CompressedPublicKey, OutPoint, Transaction, Txid,
     absolute::{Height, LockTime},
+    consensus::encode::deserialize_hex,
     hashes::{Hash, ripemd160, sha256},
     secp256k1::{Message, PublicKey, SecretKey},
 };
@@ -178,9 +179,12 @@ pub async fn run(
         style("Building challenge transaction...").bold().blue()
     );
 
+    let deposit_transaction: Transaction =
+        deserialize_hex(&challenge_data.unsigned_deposit_transaction)?;
+
     let (challenge_script, psbt) = tx_builder.build_challenge_tx(
         &challenger_pubkey.into(),
-        challenge_data.deposit_outpoint,
+        OutPoint::new(deposit_transaction.compute_txid(), 0),
         selected_commitment.to_owned(),
         LockTime::Blocks(Height::from_consensus(challenge_data.locktime)?),
         Amount::from_sat(challenge_data.amount),

--- a/apps/cli/src/actions/accept_challenge/mod.rs
+++ b/apps/cli/src/actions/accept_challenge/mod.rs
@@ -16,6 +16,7 @@ use clap::Args;
 use color_eyre::eyre;
 use console::style;
 use op_rand_prover::{BarretenbergProver, OpRandProof, OpRandProver};
+use op_rand_transaction_builder::validate_deposit_transaction;
 use op_rand_types::ThirdRankCommitment;
 use serde::{Deserialize, Serialize};
 use std::{fs, str::FromStr};
@@ -41,7 +42,6 @@ pub struct AcceptorData {
     pub acceptor_pubkey_hash: String,
     pub third_rank_commitments: [String; 2],
     pub psbt: String,
-    pub challenge_output_witness_script: String,
     pub proof: String,
     pub vk: String,
 }
@@ -182,7 +182,23 @@ pub async fn run(
     let deposit_transaction: Transaction =
         deserialize_hex(&challenge_data.unsigned_deposit_transaction)?;
 
-    let (challenge_script, psbt) = tx_builder.build_challenge_tx(
+    println!(
+        "\n{} {}",
+        SHIELD,
+        style("Validating deposit transaction...").bold().blue()
+    );
+
+    validate_deposit_transaction(&deposit_transaction, &challenger_pubkey_hash, 0)?;
+
+    println!(
+        "{} {}",
+        CHECK,
+        style("Deposit transaction validated successfully!")
+            .bold()
+            .green()
+    );
+
+    let psbt = tx_builder.build_challenge_tx(
         &challenger_pubkey.into(),
         OutPoint::new(deposit_transaction.compute_txid(), 0),
         selected_commitment.to_owned(),
@@ -235,7 +251,6 @@ pub async fn run(
         acceptor_pubkey_hash: hex::encode(ripemd160_hash),
         third_rank_commitments: challenge_data.third_rank_commitments,
         psbt: general_purpose::STANDARD.encode(psbt.serialize()),
-        challenge_output_witness_script: challenge_script.to_hex_string(),
     };
 
     let acceptor_json = serde_json::to_string(&acceptor_output)?;

--- a/apps/cli/src/actions/accept_challenge/mod.rs
+++ b/apps/cli/src/actions/accept_challenge/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use base64::{Engine as _, engine::general_purpose};
 use bitcoin::{
-    Address, Amount, CompressedPublicKey, OutPoint, PublicKey, Transaction, Txid,
+    Address, Amount, CompressedPublicKey, OutPoint, PublicKey, Transaction, Txid, WPubkeyHash,
     absolute::{Height, LockTime},
     consensus::encode::deserialize_hex,
     hashes::{Hash, sha256},
@@ -96,9 +96,7 @@ pub async fn run(
         .map_err(|_| eyre::eyre!("Expected exactly 2 commitments"))?;
 
     let challenger_pubkey = PublicKey::from_str(&challenge_data.challenger_pubkey)?;
-    let challenger_pubkey_hash = hex::decode(&challenge_data.challenger_pubkey_hash)?
-        .try_into()
-        .map_err(|_| eyre::eyre!("Failed to convert challenger public key hash to array"))?;
+    let challenger_pubkey_hash = WPubkeyHash::from_str(&challenge_data.challenger_pubkey_hash)?;
     let proof = hex::decode(&challenge_data.proof)?;
     let vk = hex::decode(&challenge_data.vk)?;
     let proof_data = OpRandProof::new(proof, vk);
@@ -112,7 +110,7 @@ pub async fn run(
     prover.verify_challenger_proof(
         commitments.clone(),
         &challenger_pubkey.inner,
-        challenger_pubkey_hash,
+        &challenger_pubkey_hash,
         &proof_data,
     )?;
 
@@ -199,7 +197,7 @@ pub async fn run(
     );
 
     let psbt = tx_builder.build_challenge_tx(
-        &challenger_pubkey.into(),
+        &challenger_pubkey,
         OutPoint::new(deposit_transaction.compute_txid(), 0),
         selected_commitment.to_owned(),
         LockTime::Blocks(Height::from_consensus(challenge_data.locktime)?),
@@ -228,12 +226,8 @@ pub async fn run(
     .await?;
     pb.finish_with_message("Acceptor circuit is set up");
     let pb = setup_progress_bar("Generating acceptor proof...".into());
-    let proof = prover.generate_acceptor_proof(
-        &public_key.inner,
-        &sig,
-        pubkey_hash.to_byte_array(),
-        commitments,
-    )?;
+    let proof =
+        prover.generate_acceptor_proof(&public_key.inner, &sig, &pubkey_hash, commitments)?;
     pb.finish_with_message("Acceptor proof generated");
 
     println!(

--- a/apps/cli/src/actions/challenge_info/mod.rs
+++ b/apps/cli/src/actions/challenge_info/mod.rs
@@ -1,9 +1,13 @@
 use std::fs;
 
+use bitcoin::{Transaction, consensus::encode};
 use clap::Args;
-use console::{Emoji, style};
+use console::style;
 
-use crate::actions::create_challenge::PublicChallengerData;
+use crate::{
+    actions::create_challenge::PublicChallengerData,
+    ui::{CHAIN, CLOCK, KEY, LOCK, ROCKET, SHIELD},
+};
 
 #[derive(Args, Debug)]
 pub struct ChallengeInfoArgs {
@@ -11,13 +15,6 @@ pub struct ChallengeInfoArgs {
     #[clap(long, default_value = "challenger.json")]
     pub challenge_file: String,
 }
-
-static ROCKET: Emoji<'_, '_> = Emoji("🚀 ", "");
-static KEY: Emoji<'_, '_> = Emoji("🔑 ", "");
-static LOCK: Emoji<'_, '_> = Emoji("🔒 ", "");
-static SHIELD: Emoji<'_, '_> = Emoji("🛡️ ", "");
-static CLOCK: Emoji<'_, '_> = Emoji("⏰ ", "");
-static CHAIN: Emoji<'_, '_> = Emoji("⛓️ ", "");
 
 pub async fn run(ChallengeInfoArgs { challenge_file }: ChallengeInfoArgs) -> eyre::Result<()> {
     let challenge_json = fs::read_to_string(&challenge_file)?;
@@ -50,6 +47,9 @@ pub async fn run(ChallengeInfoArgs { challenge_file }: ChallengeInfoArgs) -> eyr
         style(format!("{:.8}", btc_amount)).bright().green()
     );
 
+    let deposit_tx: Transaction =
+        encode::deserialize_hex(&challenge_data.unsigned_deposit_transaction)?;
+
     // Deposit information
     println!("\n{}", style("┌─ DEPOSIT INFORMATION").bold().blue());
     println!("│");
@@ -57,17 +57,11 @@ pub async fn run(ChallengeInfoArgs { challenge_file }: ChallengeInfoArgs) -> eyr
     println!(
         "│   {} {}",
         style("TXID:").dim(),
-        style(challenge_data.deposit_outpoint.txid.to_string())
+        style(deposit_tx.compute_txid().to_string())
             .bright()
             .white()
     );
-    println!(
-        "│   {} {}",
-        style("VOUT:").dim(),
-        style(challenge_data.deposit_outpoint.vout.to_string())
-            .bright()
-            .white()
-    );
+    println!("│   {} {}", style("VOUT:").dim(), style(0).bright().white());
 
     // Locktime information
     println!("│");

--- a/apps/cli/src/actions/complete_challenge/mod.rs
+++ b/apps/cli/src/actions/complete_challenge/mod.rs
@@ -9,12 +9,17 @@ use crate::{
     ui::{self, CHAIN, CHECK, GEAR, RADIO, SHIELD},
 };
 use base64::{Engine as _, engine::general_purpose};
-use bitcoin::{Amount, Psbt, consensus::Encodable};
+use bitcoin::{
+    Amount, Psbt, PublicKey, WPubkeyHash,
+    absolute::{Height, LockTime},
+    consensus::encode,
+};
 use clap::Args;
 use color_eyre::eyre;
 use color_eyre::eyre::ensure;
 use console::style;
 use op_rand_prover::{BarretenbergProver, OpRandProof, OpRandProver};
+use op_rand_transaction_builder::validate_challenge_psbt;
 use op_rand_types::{FirstRankCommitment, ThirdRankCommitment};
 
 #[derive(Args, Debug)]
@@ -150,7 +155,6 @@ pub async fn run(
             .green()
     );
 
-    // TODO: cosign the PSBT and broadcast the transaction
     let esplora_client = ctx.esplora_client()?;
     let transaction_builder = ctx.transaction_builder()?;
     let psbt_bytes = general_purpose::STANDARD.decode(&acceptor_data.psbt)?;
@@ -158,6 +162,28 @@ pub async fn run(
     let psbt = Psbt::deserialize(&psbt_bytes)?;
     let selected_first_rank_commitment =
         FirstRankCommitment::from_str(&challenger_private_data.selected_first_rank_commitment)?;
+
+    println!(
+        "\n{} {}",
+        SHIELD,
+        style("Validating challenge PSBT...").bold().blue()
+    );
+
+    validate_challenge_psbt(
+        &psbt,
+        WPubkeyHash::from_str(&acceptor_data.acceptor_pubkey_hash)?,
+        PublicKey::from_str(&challenger_data.challenger_pubkey)?,
+        LockTime::Blocks(Height::from_consensus(challenger_data.locktime)?),
+        0,
+    )?;
+
+    println!(
+        "{} {}",
+        CHECK,
+        style("Challenge PSBT validated successfully!")
+            .bold()
+            .green()
+    );
 
     println!(
         "\n{} {}",
@@ -173,9 +199,7 @@ pub async fn run(
     )?;
 
     let deposit_transaction = challenger_private_data.deposit_transaction;
-    let mut challenge_transaction_bytes = Vec::new();
-    signed_challenge_transaction.consensus_encode(&mut challenge_transaction_bytes)?;
-    let challenge_transaction = hex::encode(challenge_transaction_bytes);
+    let challenge_transaction = encode::serialize_hex(&signed_challenge_transaction);
 
     println!(
         "\n{} {}",

--- a/apps/cli/src/actions/complete_challenge/mod.rs
+++ b/apps/cli/src/actions/complete_challenge/mod.rs
@@ -83,7 +83,7 @@ pub async fn run(
     );
 
     let prover = BarretenbergProver::default();
-    let acceptor_pubkey_hash = hex::decode(&acceptor_data.acceptor_pubkey_hash)?;
+    let acceptor_pubkey_hash = WPubkeyHash::from_str(&acceptor_data.acceptor_pubkey_hash)?;
 
     println!(
         "\n{} {}",
@@ -138,9 +138,7 @@ pub async fn run(
     );
 
     prover.verify_acceptor_proof(
-        acceptor_pubkey_hash
-            .try_into()
-            .map_err(|_| eyre::eyre!("Failed to convert pubkey hash to array"))?,
+        &acceptor_pubkey_hash,
         challenger_commitments
             .try_into()
             .map_err(|_| eyre::eyre!("Failed to convert commitments to array"))?,
@@ -171,7 +169,7 @@ pub async fn run(
 
     validate_challenge_psbt(
         &psbt,
-        WPubkeyHash::from_str(&acceptor_data.acceptor_pubkey_hash)?,
+        &acceptor_pubkey_hash,
         PublicKey::from_str(&challenger_data.challenger_pubkey)?,
         LockTime::Blocks(Height::from_consensus(challenger_data.locktime)?),
         0,

--- a/apps/cli/src/actions/create_challenge/mod.rs
+++ b/apps/cli/src/actions/create_challenge/mod.rs
@@ -1,7 +1,5 @@
 use bitcoin::{
-    Address, Amount, CompressedPublicKey, OutPoint, PublicKey, Txid,
-    consensus::encode,
-    hashes::{Hash, ripemd160, sha256},
+    Address, Amount, CompressedPublicKey, OutPoint, PublicKey, Txid, consensus::encode,
     secp256k1::rand::thread_rng,
 };
 use clap::Args;
@@ -169,13 +167,13 @@ pub async fn run(
         style("2").bold().green()
     );
 
-    let challenger_pubkey_hash = PublicKey::new(tweaked_pk).wpubkey_hash()?.to_byte_array();
+    let challenger_pubkey_hash = PublicKey::new(tweaked_pk).wpubkey_hash()?;
     let pb = setup_progress_bar("Generating the challenger proof...".into());
     let proof = prover.generate_challenger_proof(
         first_rank_commitments.to_owned(),
         third_rank_commitments.to_owned(),
         &public_key,
-        challenger_pubkey_hash,
+        &challenger_pubkey_hash,
     )?;
     pb.finish_with_message("Challenger proof generated");
 

--- a/apps/cli/src/actions/create_challenge/mod.rs
+++ b/apps/cli/src/actions/create_challenge/mod.rs
@@ -163,21 +163,19 @@ pub async fn run(
 
     let third_rank_commitments = commitments.third_rank_commitments();
 
-    let sha256_hash = sha256::Hash::hash(&tweaked_pk.serialize());
-    let ripemd160_hash = ripemd160::Hash::hash(sha256_hash.as_byte_array());
-
     println!(
         "{} {} third-rank commitments generated",
         CHECK,
         style("2").bold().green()
     );
 
+    let challenger_pubkey_hash = PublicKey::new(tweaked_pk).wpubkey_hash()?.to_byte_array();
     let pb = setup_progress_bar("Generating the challenger proof...".into());
     let proof = prover.generate_challenger_proof(
         first_rank_commitments.to_owned(),
         third_rank_commitments.to_owned(),
         &public_key,
-        ripemd160_hash.to_byte_array(),
+        challenger_pubkey_hash,
     )?;
     pb.finish_with_message("Challenger proof generated");
 
@@ -242,7 +240,7 @@ pub async fn run(
             hex::encode(third_rank_commitments[1].inner().serialize()),
         ],
         challenger_pubkey: hex::encode(public_key.serialize()),
-        challenger_pubkey_hash: hex::encode(ripemd160_hash.to_byte_array()),
+        challenger_pubkey_hash: hex::encode(challenger_pubkey_hash),
         proof: hex::encode(proof.proof()),
         vk: hex::encode(proof.vk()),
         locktime,

--- a/apps/cli/src/actions/create_challenge/mod.rs
+++ b/apps/cli/src/actions/create_challenge/mod.rs
@@ -1,6 +1,6 @@
 use bitcoin::{
     Address, Amount, CompressedPublicKey, OutPoint, PublicKey, Txid,
-    consensus::Encodable,
+    consensus::{Encodable, encode},
     hashes::{Hash, ripemd160, sha256},
     secp256k1::rand::thread_rng,
 };
@@ -52,7 +52,7 @@ pub struct CreateChallengeArgs {
 pub struct PublicChallengerData {
     pub id: String,
     pub amount: u64,
-    pub deposit_outpoint: OutPoint,
+    pub unsigned_deposit_transaction: String,
     pub third_rank_commitments: [String; 2],
     pub challenger_pubkey: String,
     pub challenger_pubkey_hash: String,
@@ -236,7 +236,7 @@ pub async fn run(
     let public_challenge_output = PublicChallengerData {
         id: id.clone(),
         amount,
-        deposit_outpoint: OutPoint::new(deposit_tx.compute_txid(), 0),
+        unsigned_deposit_transaction: hex::encode(encode::serialize_hex(&deposit_tx)),
         third_rank_commitments: [
             hex::encode(third_rank_commitments[0].inner().serialize()),
             hex::encode(third_rank_commitments[1].inner().serialize()),

--- a/apps/cli/src/actions/create_challenge/mod.rs
+++ b/apps/cli/src/actions/create_challenge/mod.rs
@@ -1,6 +1,6 @@
 use bitcoin::{
     Address, Amount, CompressedPublicKey, OutPoint, PublicKey, Txid,
-    consensus::{Encodable, encode},
+    consensus::encode,
     hashes::{Hash, ripemd160, sha256},
     secp256k1::rand::thread_rng,
 };
@@ -56,9 +56,9 @@ pub struct PublicChallengerData {
     pub third_rank_commitments: [String; 2],
     pub challenger_pubkey: String,
     pub challenger_pubkey_hash: String,
+    pub locktime: u32,
     pub proof: String,
     pub vk: String,
-    pub locktime: u32,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -236,7 +236,7 @@ pub async fn run(
     let public_challenge_output = PublicChallengerData {
         id: id.clone(),
         amount,
-        unsigned_deposit_transaction: hex::encode(encode::serialize_hex(&deposit_tx)),
+        unsigned_deposit_transaction: encode::serialize_hex(&deposit_tx),
         third_rank_commitments: [
             hex::encode(third_rank_commitments[0].inner().serialize()),
             hex::encode(third_rank_commitments[1].inner().serialize()),
@@ -251,13 +251,10 @@ pub async fn run(
     let json_output = serde_json::to_string_pretty(&public_challenge_output)?;
     fs::write(&public_output, json_output)?;
 
-    let mut tx_bytes = Vec::new();
-    deposit_tx.consensus_encode(&mut tx_bytes)?;
-
     let private_challenge_output = PrivateChallengerData {
         id: id.clone(),
         amount,
-        deposit_transaction: hex::encode(tx_bytes),
+        deposit_transaction: encode::serialize_hex(&deposit_tx),
         first_rank_commitments: [
             hex::encode(first_rank_commitments[0].inner().0.secret_bytes()),
             hex::encode(first_rank_commitments[1].inner().0.secret_bytes()),

--- a/apps/cli/src/actions/try_spend/mod.rs
+++ b/apps/cli/src/actions/try_spend/mod.rs
@@ -1,7 +1,7 @@
 use std::{fs, str::FromStr};
 
 use bitcoin::{
-    Amount, PublicKey, Transaction,
+    Amount, PublicKey, Transaction, WPubkeyHash,
     absolute::{Height, LockTime},
     consensus::Decodable,
 };
@@ -117,13 +117,10 @@ pub async fn run(
                 .blue()
         );
 
-        let witness_script =
-            bitcoin::ScriptBuf::from_hex(&acceptor_data.challenge_output_witness_script)?;
-
         let sweep_tx = tx_builder.sweep_challenge_output_challenger(
             &challenge_transaction,
-            &witness_script,
             LockTime::Blocks(Height::from_consensus(challenger_data.locktime)?),
+            WPubkeyHash::from_str(&acceptor_data.acceptor_pubkey_hash)?,
             recipient_pubkey,
             fee_amount,
         )?;
@@ -171,17 +168,11 @@ pub async fn run(
                 .blue()
         );
 
-        let witness_script_bytes = hex::decode(&acceptor_data.challenge_output_witness_script)?;
-        let witness_script = bitcoin::ScriptBuf::from_bytes(witness_script_bytes);
-
-        let challenger_pubkey_bytes = hex::decode(&challenger_data.challenger_pubkey)?;
-        let challenger_pubkey = bitcoin::PublicKey::from_slice(&challenger_pubkey_bytes)?;
-
         let sweep_tx = tx_builder.sweep_challenge_output_acceptor(
             &challenge_transaction,
-            &challenger_pubkey,
-            &witness_script,
+            &PublicKey::from_str(&challenger_data.challenger_pubkey)?,
             recipient_pubkey,
+            LockTime::Blocks(Height::from_consensus(challenger_data.locktime)?),
             fee_amount,
         )?;
 

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -3,12 +3,14 @@ use console::{Emoji, style};
 pub static CHECK: Emoji<'_, '_> = Emoji("✅ ", "");
 pub static GEAR: Emoji<'_, '_> = Emoji("⚙️ ", "");
 pub static SHIELD: Emoji<'_, '_> = Emoji("🛡️ ", "");
-pub static KEY: Emoji<'_, '_> = Emoji("�� ", "");
+pub static KEY: Emoji<'_, '_> = Emoji("🔑 ", "");
 pub static CHAIN: Emoji<'_, '_> = Emoji("⛓️ ", "");
 pub static RADIO: Emoji<'_, '_> = Emoji("📡 ", "");
 pub static SPARKLES: Emoji<'_, '_> = Emoji("✨ ", "");
 pub static CLOCK: Emoji<'_, '_> = Emoji("⏰ ", "");
 pub static TARGET: Emoji<'_, '_> = Emoji("🎯 ", "");
+pub static ROCKET: Emoji<'_, '_> = Emoji("🚀 ", "");
+pub static LOCK: Emoji<'_, '_> = Emoji("🔒 ", "");
 
 pub fn header(text: &str) -> String {
     format!(

--- a/crates/prover/src/backends/barretenberg.rs
+++ b/crates/prover/src/backends/barretenberg.rs
@@ -1,4 +1,5 @@
-use bitcoin::secp256k1;
+use bitcoin::hashes::Hash;
+use bitcoin::{WPubkeyHash, secp256k1};
 use noir_rs::barretenberg::srs::setup_srs;
 use noir_rs::barretenberg::{prove::prove_ultra_honk, verify::verify_ultra_honk};
 use noir_rs::witness::from_vec_str_to_witness_map;
@@ -39,7 +40,7 @@ impl OpRandProver for BarretenbergProver {
         first_rank_commitments: [FirstRankCommitment; 2],
         third_rank_commitments: [ThirdRankCommitment; 2],
         challenger_public_key: &secp256k1::PublicKey,
-        challenger_public_key_hash: [u8; 20],
+        challenger_public_key_hash: &WPubkeyHash,
     ) -> Result<OpRandProof, crate::errors::ProverError> {
         // Extract the x and y coordinates from the challenger's public key
         let pk_coords = challenger_public_key.serialize_uncompressed();
@@ -74,7 +75,9 @@ impl OpRandProver for BarretenbergProver {
         witness_inputs.extend(bytes_to_string_array(h2_y)); // H2_y (32 bytes)
         witness_inputs.extend(bytes_to_string_array(pk_x)); // PK_x (32 bytes)
         witness_inputs.extend(bytes_to_string_array(pk_y)); // PK_y (32 bytes)
-        witness_inputs.extend(bytes_to_string_array(&challenger_public_key_hash)); // ADDR (20 bytes)
+        witness_inputs.extend(bytes_to_string_array(
+            &challenger_public_key_hash.as_raw_hash().to_byte_array(),
+        )); // ADDR (20 bytes)
 
         let witness_input_refs = witness_inputs
             .iter()
@@ -98,7 +101,7 @@ impl OpRandProver for BarretenbergProver {
         &self,
         _third_rank_commitments: [ThirdRankCommitment; 2],
         _challenger_public_key: &secp256k1::PublicKey,
-        _challenger_public_key_hash: [u8; 20],
+        _challenger_public_key_hash: &WPubkeyHash,
         proof: &OpRandProof,
     ) -> Result<(), crate::errors::ProverError> {
         // TODO: Add verification of public inputs
@@ -116,7 +119,7 @@ impl OpRandProver for BarretenbergProver {
         &self,
         acceptor_public_key: &secp256k1::PublicKey,
         acceptor_signature: &secp256k1::ecdsa::Signature,
-        acceptor_public_key_hash: [u8; 20],
+        acceptor_public_key_hash: &WPubkeyHash,
         third_rank_commitments: [ThirdRankCommitment; 2],
     ) -> Result<OpRandProof, crate::errors::ProverError> {
         // Extract the x and y coordinates from the acceptor's public key
@@ -147,7 +150,9 @@ impl OpRandProver for BarretenbergProver {
         witness_inputs.extend(bytes_to_string_array(h1_y)); // H1_y (32 bytes)
         witness_inputs.extend(bytes_to_string_array(h2_x)); // H2_x (32 bytes)
         witness_inputs.extend(bytes_to_string_array(h2_y)); // H2_y (32 bytes)
-        witness_inputs.extend(bytes_to_string_array(&acceptor_public_key_hash)); // ADDR (20 bytes)
+        witness_inputs.extend(bytes_to_string_array(
+            &acceptor_public_key_hash.as_raw_hash().to_byte_array(),
+        )); // ADDR (20 bytes)
 
         let witness_input_refs = witness_inputs
             .iter()
@@ -169,7 +174,7 @@ impl OpRandProver for BarretenbergProver {
 
     fn verify_acceptor_proof(
         &self,
-        _acceptor_public_key_hash: [u8; 20],
+        _acceptor_public_key_hash: &WPubkeyHash,
         _third_rank_commitments: [ThirdRankCommitment; 2],
         op_rand_proof: &OpRandProof,
     ) -> Result<(), crate::errors::ProverError> {

--- a/crates/prover/src/traits/prover.rs
+++ b/crates/prover/src/traits/prover.rs
@@ -1,4 +1,4 @@
-use bitcoin::secp256k1;
+use bitcoin::{WPubkeyHash, secp256k1};
 use op_rand_types::{FirstRankCommitment, ThirdRankCommitment};
 use secp256k1::{PublicKey, ecdsa};
 
@@ -15,14 +15,14 @@ pub trait OpRandProver {
         first_rank_commitments: [FirstRankCommitment; 2],
         third_rank_commitments: [ThirdRankCommitment; 2],
         challenger_public_key: &PublicKey,
-        challenger_public_key_hash: [u8; 20],
+        challenger_public_key_hash: &WPubkeyHash,
     ) -> Result<OpRandProof, ProverError>;
     /// Used by the acceptor to verify the proof from the challenger
     fn verify_challenger_proof(
         &self,
         third_rank_commitments: [ThirdRankCommitment; 2],
         challenger_public_key: &secp256k1::PublicKey,
-        challenger_public_key_hash: [u8; 20],
+        challenger_public_key_hash: &WPubkeyHash,
         proof: &OpRandProof,
     ) -> Result<(), ProverError>;
 
@@ -31,13 +31,13 @@ pub trait OpRandProver {
         &self,
         acceptor_public_key: &PublicKey,
         acceptor_signature: &ecdsa::Signature,
-        acceptor_public_key_hash: [u8; 20],
+        acceptor_public_key_hash: &WPubkeyHash,
         third_rank_commitments: [ThirdRankCommitment; 2],
     ) -> Result<OpRandProof, ProverError>;
     /// Used by the challenger to verify the proof from the acceptor
     fn verify_acceptor_proof(
         &self,
-        acceptor_public_key_hash: [u8; 20],
+        acceptor_public_key_hash: &WPubkeyHash,
         third_rank_commitments: [ThirdRankCommitment; 2],
         proof: &OpRandProof,
     ) -> Result<(), ProverError>;

--- a/crates/transaction-builder/Cargo.toml
+++ b/crates/transaction-builder/Cargo.toml
@@ -8,3 +8,4 @@ bitcoin = { workspace = true }
 miniscript = { workspace = true }
 op-rand-types = { workspace = true }
 thiserror = { workspace = true }
+eyre = { workspace = true }

--- a/crates/transaction-builder/src/lib.rs
+++ b/crates/transaction-builder/src/lib.rs
@@ -1,5 +1,7 @@
 mod errors;
 mod scripts;
 mod transaction_builder;
+mod transaction_signer;
 
 pub use transaction_builder::TransactionBuilder;
+pub use transaction_signer::TransactionSigner;

--- a/crates/transaction-builder/src/lib.rs
+++ b/crates/transaction-builder/src/lib.rs
@@ -2,6 +2,9 @@ mod errors;
 mod scripts;
 mod transaction_builder;
 mod transaction_signer;
+mod validations;
 
 pub use transaction_builder::TransactionBuilder;
 pub use transaction_signer::TransactionSigner;
+
+pub use validations::{validate_challenge_psbt, validate_deposit_transaction};

--- a/crates/transaction-builder/src/scripts.rs
+++ b/crates/transaction-builder/src/scripts.rs
@@ -36,7 +36,7 @@ pub(crate) fn create_p2wpkh_script(public_key: &PublicKey) -> Result<ScriptBuf, 
 /// ```
 pub(crate) fn create_challenge_p2wsh_script(
     challenger_pubkey: &PublicKey,
-    tweaked_acceptor_pubkey_hash: WPubkeyHash,
+    tweaked_acceptor_pubkey_hash: &WPubkeyHash,
     lock_time: LockTime,
 ) -> Result<ScriptBuf, TransactionError> {
     let script = script::Builder::new()

--- a/crates/transaction-builder/src/scripts.rs
+++ b/crates/transaction-builder/src/scripts.rs
@@ -1,4 +1,5 @@
 use bitcoin::{
+    WPubkeyHash,
     absolute::LockTime,
     key::PublicKey,
     opcodes,
@@ -14,23 +15,36 @@ pub(crate) fn create_p2wpkh_script(public_key: &PublicKey) -> Result<ScriptBuf, 
     Ok(ScriptBuf::new_p2wpkh(&witness_pubkey_hash))
 }
 
-/// Creates a custom script for challenge transaction output:  
-/// ```_
+/// Constructs a challenge output script for a P2WSH address with conditional spending logic.
+///
+/// The script allows two spending paths:
+///
+/// - **If branch (`OP_IF`)**: Can be spent immediately with a signature from the acceptor,
+///   but requires that the provided public key matches the `HASH160` of the tweaked acceptor's public key.
+///
+/// - **Else branch (`OP_ELSE`)**: Allows the challenger to spend the output after a specified `lock_time`,
+///   using their own signature.
+///
+/// Script structure:
+/// ```text
 /// OP_IF
-///     <P_a + H> OP_CHECKSIG
-/// OP_ELSE  
-///     <LT> OP_CHECKLOCKTIMEVERIFY OP_DROP  
-///     <P_c> OP_CHECKSIG  
+///     OP_DUP <HASH160(P_a + H)> OP_EQUALVERIFY OP_CHECKSIG
+/// OP_ELSE
+///     <lock_time> OP_CHECKLOCKTIMEVERIFY OP_DROP
+///     <P_c> OP_CHECKSIG
 /// OP_ENDIF
+/// ```
 pub(crate) fn create_challenge_p2wsh_script(
     challenger_pubkey: &PublicKey,
-    tweaked_acceptor_pubkey: &PublicKey,
+    tweaked_acceptor_pubkey_hash: WPubkeyHash,
     lock_time: LockTime,
-) -> ScriptBuf {
-    script::Builder::new()
+) -> Result<ScriptBuf, TransactionError> {
+    let script = script::Builder::new()
         .push_opcode(opcodes::all::OP_IF)
-        // TODO: it should be a hash of the public key
-        .push_key(tweaked_acceptor_pubkey)
+        .push_opcode(opcodes::all::OP_DUP)
+        .push_opcode(opcodes::all::OP_HASH160)
+        .push_slice(tweaked_acceptor_pubkey_hash)
+        .push_opcode(opcodes::all::OP_EQUALVERIFY)
         .push_opcode(opcodes::all::OP_CHECKSIG)
         .push_opcode(opcodes::all::OP_ELSE)
         .push_lock_time(lock_time)
@@ -39,5 +53,7 @@ pub(crate) fn create_challenge_p2wsh_script(
         .push_key(challenger_pubkey)
         .push_opcode(opcodes::all::OP_CHECKSIG)
         .push_opcode(opcodes::all::OP_ENDIF)
-        .into_script()
+        .into_script();
+
+    Ok(script)
 }

--- a/crates/transaction-builder/src/transaction_builder.rs
+++ b/crates/transaction-builder/src/transaction_builder.rs
@@ -1,5 +1,5 @@
 use bitcoin::{
-    Amount, OutPoint, Psbt, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+    Amount, OutPoint, Psbt, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut, WPubkeyHash,
     absolute::LockTime,
     hashes::{Hash, sha256},
     key::{Secp256k1, Verification},
@@ -118,15 +118,15 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         previous_outputs: Vec<(OutPoint, Amount)>,
         change_amount: Option<Amount>,
         change_pubkey: Option<PublicKey>,
-    ) -> Result<(ScriptBuf, Psbt), TransactionError> {
+    ) -> Result<Psbt, TransactionError> {
         // Combine the chosen third rank commitment with the acceptor's public key to get the challenge public key
         let tweaked_acceptor_pubkey = third_rank_commitment.combine(&self.public_key.inner)?;
 
         let challenge_script = create_challenge_p2wsh_script(
             challenger_pubkey,
-            &PublicKey::new(tweaked_acceptor_pubkey),
+            PublicKey::new(tweaked_acceptor_pubkey).wpubkey_hash()?,
             lock_time,
-        );
+        )?;
 
         let mut outputs = vec![TxOut {
             value: amount * 2,
@@ -165,7 +165,7 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
                 .sign_psbt_input(&mut psbt, input_index + 1, *amount, None)?;
         }
 
-        Ok((challenge_script, psbt))
+        Ok(psbt)
     }
 
     /// This method should be used by the Challenger to complete the challenge transaction.
@@ -201,8 +201,8 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         &self,
         challenge_transaction: &Transaction,
         challenger_pubkey: &PublicKey,
-        witness_script: &ScriptBuf,
         recipient_pubkey: Option<PublicKey>,
+        lock_time: LockTime,
         fee: Amount,
     ) -> Result<Transaction, TransactionError> {
         let inputs = vec![TxIn {
@@ -235,8 +235,9 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
             &mut tx,
             0,
             challenge_transaction.output[0].value,
-            witness_script,
+            challenger_pubkey,
             second_rank_commitment_sk,
+            lock_time,
         )?;
 
         Ok(tx)
@@ -248,8 +249,8 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
     pub fn sweep_challenge_output_challenger(
         &self,
         challenge_transaction: &Transaction,
-        witness_script: &ScriptBuf,
         lock_time: LockTime,
+        acceptor_pubkey_hash: WPubkeyHash,
         recipient_pubkey: Option<PublicKey>,
         fee: Amount,
     ) -> Result<Transaction, TransactionError> {
@@ -265,13 +266,15 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         }];
 
         let mut tx = create_tx(inputs, outputs, Some(lock_time));
+        let witness_script =
+            create_challenge_p2wsh_script(&self.public_key, acceptor_pubkey_hash, lock_time)?;
 
         // Challenger sweep tx is signed by the original secret key
         self.signer.sign_p2wsh_input_challenger(
             &mut tx,
             0,
             challenge_transaction.output[0].value,
-            witness_script,
+            &witness_script,
         )?;
 
         Ok(tx)

--- a/crates/transaction-builder/src/transaction_builder.rs
+++ b/crates/transaction-builder/src/transaction_builder.rs
@@ -1,12 +1,9 @@
 use bitcoin::{
-    Amount, EcdsaSighashType, OutPoint, Psbt, PublicKey, ScriptBuf, Sequence, Transaction, TxIn,
-    TxOut,
+    Amount, OutPoint, Psbt, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
     absolute::LockTime,
     hashes::{Hash, sha256},
     key::{Secp256k1, Verification},
-    psbt::PsbtSighashType,
-    secp256k1::{self, All, Context, Message, SecretKey, Signing},
-    sighash::SighashCache,
+    secp256k1::{self, All, Context, SecretKey, Signing},
     transaction::Version,
 };
 use miniscript::psbt::PsbtExt;
@@ -15,28 +12,34 @@ use op_rand_types::{FirstRankCommitment, ThirdRankCommitment};
 use crate::{
     errors::TransactionError,
     scripts::{create_challenge_p2wsh_script, create_p2wpkh_script},
+    transaction_signer::TransactionSigner,
 };
 
 /// `TransactionBuilder` is used by both parties to build deposit and challenge transactions.
 #[derive(Debug, Clone)]
 pub struct TransactionBuilder<C: Context> {
-    secret_key: SecretKey,
-    ctx: Secp256k1<C>,
+    public_key: PublicKey,
+    signer: TransactionSigner<C>,
 }
 
 impl From<SecretKey> for TransactionBuilder<All> {
     fn from(secret_key: SecretKey) -> Self {
-        let ctx = Secp256k1::new();
-        TransactionBuilder { secret_key, ctx }
+        let signer = TransactionSigner::from(secret_key);
+        let public_key = secret_key.public_key(signer.ctx());
+        TransactionBuilder {
+            signer,
+            public_key: public_key.into(),
+        }
     }
 }
 
 impl From<&SecretKey> for TransactionBuilder<All> {
     fn from(secret_key: &SecretKey) -> Self {
-        let ctx = Secp256k1::new();
+        let signer = TransactionSigner::from(secret_key);
+        let public_key = secret_key.public_key(signer.ctx());
         TransactionBuilder {
-            secret_key: *secret_key,
-            ctx,
+            signer,
+            public_key: public_key.into(),
         }
     }
 }
@@ -44,7 +47,12 @@ impl From<&SecretKey> for TransactionBuilder<All> {
 impl<C: Signing + Verification> TransactionBuilder<C> {
     /// Creates a new `TransactionBuilder` with the given secret key and context.
     pub fn new(secret_key: SecretKey, ctx: Secp256k1<C>) -> Self {
-        TransactionBuilder { secret_key, ctx }
+        let signer = TransactionSigner::new(secret_key, ctx);
+        let public_key = secret_key.public_key(signer.ctx());
+        TransactionBuilder {
+            signer,
+            public_key: public_key.into(),
+        }
     }
 
     /// This method should be used by the Challenger to build a deposit transaction.
@@ -59,11 +67,8 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         change_amount: Option<Amount>,
         change_pubkey: Option<PublicKey>,
     ) -> Result<Transaction, TransactionError> {
-        let secp_public_key = self.secret_key.public_key(&self.ctx);
-        let public_key = PublicKey::new(secp_public_key);
-
         // Combine the chosen first rank commitment with the public key to get the challenge public key
-        let challenge_pubkey = first_rank_commitment.combine(&public_key.inner)?;
+        let challenge_pubkey = first_rank_commitment.combine(&self.public_key.inner)?;
         let deposit_script = create_p2wpkh_script(&challenge_pubkey.into())?;
 
         let mut outputs = vec![TxOut {
@@ -72,7 +77,7 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         }];
 
         if let Some(change_amount) = change_amount {
-            let change_script = create_p2wpkh_script(&change_pubkey.unwrap_or(public_key))?;
+            let change_script = create_p2wpkh_script(&change_pubkey.unwrap_or(self.public_key))?;
             outputs.push(TxOut {
                 value: change_amount,
                 script_pubkey: change_script,
@@ -90,7 +95,7 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         let amounts = previous_outputs.iter().map(|(_, amount)| *amount).collect();
 
         let mut deposit_tx = create_tx(inputs, outputs, None);
-        self.sign_transaction(&mut deposit_tx, amounts)?;
+        self.signer.sign_transaction(&mut deposit_tx, amounts)?;
 
         Ok(deposit_tx)
     }
@@ -114,10 +119,8 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         change_amount: Option<Amount>,
         change_pubkey: Option<PublicKey>,
     ) -> Result<(ScriptBuf, Psbt), TransactionError> {
-        let acceptor_public_key = self.secret_key.public_key(&self.ctx);
-
         // Combine the chosen third rank commitment with the acceptor's public key to get the challenge public key
-        let tweaked_acceptor_pubkey = third_rank_commitment.combine(&acceptor_public_key)?;
+        let tweaked_acceptor_pubkey = third_rank_commitment.combine(&self.public_key.inner)?;
 
         let challenge_script = create_challenge_p2wsh_script(
             challenger_pubkey,
@@ -131,9 +134,7 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         }];
 
         if let Some(change_amount) = change_amount {
-            let change_script = create_p2wpkh_script(
-                &change_pubkey.unwrap_or(PublicKey::new(acceptor_public_key)),
-            )?;
+            let change_script = create_p2wpkh_script(&change_pubkey.unwrap_or(self.public_key))?;
             outputs.push(TxOut {
                 value: change_amount,
                 script_pubkey: change_script,
@@ -160,7 +161,8 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
 
         for (input_index, (_, amount)) in previous_outputs.iter().enumerate() {
             // Increment input index by 1 to skip the deposit input
-            self.sign_psbt_input(&mut psbt, input_index + 1, *amount, None)?;
+            self.signer
+                .sign_psbt_input(&mut psbt, input_index + 1, *amount, None)?;
         }
 
         Ok((challenge_script, psbt))
@@ -176,18 +178,20 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         first_rank_commitment: FirstRankCommitment,
     ) -> Result<Transaction, TransactionError> {
         // Sign the deposit transaction output using the chosen first rank commitment
-        let deposit_signing_key = first_rank_commitment.add_tweak(&self.secret_key)?;
-        self.sign_psbt_input(
+        self.signer.sign_psbt_input(
             &mut psbt,
             deposit_input_index,
             deposit_amount,
-            Some(deposit_signing_key),
+            Some(first_rank_commitment),
         )?;
 
-        psbt.finalize_mut(&self.ctx)?;
+        psbt.finalize_mut(self.signer.ctx())?;
 
-        psbt.extract_tx()
-            .map_err(|_e| TransactionError::ExtractTransactionFailed)
+        let tx = psbt
+            .extract_tx()
+            .map_err(|_e| TransactionError::ExtractTransactionFailed)?;
+
+        Ok(tx)
     }
 
     /// This method should be used by the Acceptor to sweep the challenge output.
@@ -208,9 +212,7 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
 
         let outputs = vec![TxOut {
             value: challenge_transaction.output[0].value - fee,
-            script_pubkey: create_p2wpkh_script(
-                &recipient_pubkey.unwrap_or(self.secret_key.public_key(&self.ctx).into()),
-            )?,
+            script_pubkey: create_p2wpkh_script(&recipient_pubkey.unwrap_or(self.public_key))?,
         }];
 
         // Extract the witness stack from the deposit input
@@ -221,62 +223,23 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
             .map_err(|_e| TransactionError::Secp256k1(secp256k1::Error::InvalidPublicKey))?;
 
         // Extract the second rank commitment by subtracting challenger_pubkey from witness_pubkey
-        let negated_challenger_pubkey = challenger_pubkey.inner.negate(&self.ctx);
+        let negated_challenger_pubkey = challenger_pubkey.inner.negate(self.signer.ctx());
         let second_rank_commitment = witness_pubkey.inner.combine(&negated_challenger_pubkey)?;
         let second_rank_commitment_hash = sha256::Hash::hash(&second_rank_commitment.serialize());
         let second_rank_commitment_sk =
             SecretKey::from_slice(second_rank_commitment_hash.as_byte_array())?;
 
-        // Add the second rank commitment to the acceptor's secret key to get the tweaked secret key
-        let tweaked_acceptor_sk = self
-            .secret_key
-            .add_tweak(&second_rank_commitment_sk.into())?;
-
         let mut tx = create_tx(inputs, outputs, None);
 
-        self.sign_p2wsh_input_acceptor(
+        self.signer.sign_p2wsh_input_acceptor(
             &mut tx,
             0,
             challenge_transaction.output[0].value,
             witness_script,
-            tweaked_acceptor_sk,
+            second_rank_commitment_sk,
         )?;
 
         Ok(tx)
-    }
-
-    /// Signs a p2wsh input for the acceptor using the OP_IF (immediate) branch
-    fn sign_p2wsh_input_acceptor(
-        &self,
-        tx: &mut Transaction,
-        input_index: usize,
-        amount: Amount,
-        witness_script: &ScriptBuf,
-        tweaked_secret_key: SecretKey,
-    ) -> Result<(), TransactionError> {
-        let mut sighash_cache = SighashCache::new(&*tx);
-        let sighash = sighash_cache
-            .p2wsh_signature_hash(input_index, witness_script, amount, EcdsaSighashType::All)
-            .map_err(|_e| TransactionError::FailedToSignP2wshInput)?;
-
-        let message = Message::from_digest_slice(sighash.as_ref())?;
-        let signature = self.ctx.sign_ecdsa(&message, &tweaked_secret_key);
-
-        let mut final_signature = signature.serialize_der().to_vec();
-        final_signature.push(EcdsaSighashType::All as u8);
-
-        let tx_input = tx
-            .input
-            .get_mut(input_index)
-            .ok_or(TransactionError::InputIndexOutOfBounds)?;
-
-        // Build witness for OP_IF branch: <signature> <1> <witness_script>
-        tx_input.witness.clear();
-        tx_input.witness.push(final_signature); // Acceptor's signature with tweaked key
-        tx_input.witness.push(vec![1]); // Push 1 to take OP_IF branch
-        tx_input.witness.push(witness_script.to_bytes()); // The witness script
-
-        Ok(())
     }
 
     /// This method should be used by the Challenger to sweep the challenge output.
@@ -290,8 +253,6 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         recipient_pubkey: Option<PublicKey>,
         fee: Amount,
     ) -> Result<Transaction, TransactionError> {
-        let challenger_pubkey = self.secret_key.public_key(&self.ctx);
-
         let inputs = vec![TxIn {
             previous_output: OutPoint::new(challenge_transaction.compute_txid(), 0),
             sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
@@ -300,15 +261,13 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
 
         let outputs = vec![TxOut {
             value: challenge_transaction.output[0].value - fee,
-            script_pubkey: create_p2wpkh_script(
-                &recipient_pubkey.unwrap_or(PublicKey::new(challenger_pubkey)),
-            )?,
+            script_pubkey: create_p2wpkh_script(&recipient_pubkey.unwrap_or(self.public_key))?,
         }];
 
         let mut tx = create_tx(inputs, outputs, Some(lock_time));
 
         // Challenger sweep tx is signed by the original secret key
-        self.sign_p2wsh_input_challenger(
+        self.signer.sign_p2wsh_input_challenger(
             &mut tx,
             0,
             challenge_transaction.output[0].value,
@@ -316,144 +275,6 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
         )?;
 
         Ok(tx)
-    }
-
-    /// Signs a p2wsh input for the challenger using the OP_ELSE (delayed) branch
-    fn sign_p2wsh_input_challenger(
-        &self,
-        tx: &mut Transaction,
-        input_index: usize,
-        amount: Amount,
-        witness_script: &ScriptBuf,
-    ) -> Result<(), TransactionError> {
-        let mut sighash_cache = SighashCache::new(&*tx);
-        let sighash = sighash_cache
-            .p2wsh_signature_hash(input_index, witness_script, amount, EcdsaSighashType::All)
-            .map_err(|_e| TransactionError::FailedToSignP2wshInput)?;
-
-        let message = Message::from_digest_slice(sighash.as_ref())?;
-        let signature = self.ctx.sign_ecdsa(&message, &self.secret_key);
-
-        let mut final_signature = signature.serialize_der().to_vec();
-        final_signature.push(EcdsaSighashType::All as u8);
-
-        let tx_input = tx
-            .input
-            .get_mut(input_index)
-            .ok_or(TransactionError::InputIndexOutOfBounds)?;
-
-        // Build witness for OP_ELSE branch: <signature> <0> <witness_script>
-        tx_input.witness.clear();
-        tx_input.witness.push(final_signature); // Challenger's signature
-        tx_input.witness.push(vec![]); // Push 0 to take OP_ELSE branch
-        tx_input.witness.push(witness_script.to_bytes()); // The witness script
-
-        Ok(())
-    }
-
-    /// Signs a single input inside `Transaction` by its index
-    fn sign_single_input(
-        &self,
-        tx: &mut Transaction,
-        input_index: usize,
-        amount: Amount,
-    ) -> Result<(), TransactionError> {
-        let public_key = self.secret_key.public_key(&self.ctx);
-        let script_code = ScriptBuf::new_p2wpkh(&PublicKey::new(public_key).wpubkey_hash()?);
-
-        let mut sighash_cache = SighashCache::new(&*tx);
-        let sighash = sighash_cache.p2wpkh_signature_hash(
-            input_index,
-            &script_code,
-            amount,
-            EcdsaSighashType::All,
-        )?;
-
-        let tx_input = tx
-            .input
-            .get_mut(input_index)
-            .ok_or(TransactionError::InputIndexOutOfBounds)?;
-
-        let message = Message::from_digest_slice(sighash.as_ref())?;
-        let signature = self.ctx.sign_ecdsa(&message, &self.secret_key);
-
-        let mut final_signature = signature.serialize_der().to_vec();
-        final_signature.push(EcdsaSighashType::All as u8);
-
-        tx_input.witness.clear();
-        tx_input.witness.push(final_signature);
-        tx_input.witness.push(public_key.serialize());
-
-        Ok(())
-    }
-
-    /// Signs a single input inside `Psbt` by its index
-    /// If the secret key is not provided, the original secret key will be used
-    fn sign_psbt_input(
-        &self,
-        psbt: &mut Psbt,
-        input_index: usize,
-        amount: Amount,
-        secret_key: Option<SecretKey>,
-    ) -> Result<(), TransactionError> {
-        let psbt_input = psbt
-            .inputs
-            .get_mut(input_index)
-            .ok_or(TransactionError::InputIndexOutOfBounds)?;
-
-        let secret_key = secret_key.unwrap_or(self.secret_key);
-        let public_key = secret_key.public_key(&self.ctx);
-        let script_pubkey = create_p2wpkh_script(&public_key.into())?;
-
-        let mut sighasher = SighashCache::new(&psbt.unsigned_tx);
-        let sighash = sighasher.p2wpkh_signature_hash(
-            input_index,
-            &script_pubkey,
-            amount,
-            EcdsaSighashType::All,
-        )?;
-
-        let message = Message::from_digest_slice(sighash.as_ref())?;
-        let signature = self.ctx.sign_ecdsa(&message, &secret_key);
-
-        let final_signature = bitcoin::ecdsa::Signature {
-            signature,
-            sighash_type: EcdsaSighashType::All,
-        };
-
-        psbt_input
-            .partial_sigs
-            .insert(PublicKey::new(public_key), final_signature);
-
-        let witness_utxo = TxOut {
-            value: amount,
-            script_pubkey,
-        };
-        psbt_input.witness_utxo = Some(witness_utxo);
-
-        let psbt_sighash_type = PsbtSighashType::from(EcdsaSighashType::All);
-        if psbt_input.sighash_type.is_none() {
-            psbt_input.sighash_type = Some(psbt_sighash_type);
-        }
-
-        Ok(())
-    }
-
-    /// Signs all transaction inputs with the same secret key
-    fn sign_transaction(
-        &self,
-        tx: &mut Transaction,
-        amounts: Vec<Amount>,
-    ) -> Result<(), TransactionError> {
-        if tx.input.len() != amounts.len() {
-            return Err(TransactionError::InputsOutputsLengthMismatch);
-        }
-
-        for (input_index, amount) in amounts.iter().enumerate() {
-            self.sign_single_input(tx, input_index, *amount)?;
-        }
-
-        Ok(())
     }
 }
 

--- a/crates/transaction-builder/src/transaction_builder.rs
+++ b/crates/transaction-builder/src/transaction_builder.rs
@@ -124,7 +124,7 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
 
         let challenge_script = create_challenge_p2wsh_script(
             challenger_pubkey,
-            PublicKey::new(tweaked_acceptor_pubkey).wpubkey_hash()?,
+            &PublicKey::new(tweaked_acceptor_pubkey).wpubkey_hash()?,
             lock_time,
         )?;
 
@@ -267,7 +267,7 @@ impl<C: Signing + Verification> TransactionBuilder<C> {
 
         let mut tx = create_tx(inputs, outputs, Some(lock_time));
         let witness_script =
-            create_challenge_p2wsh_script(&self.public_key, acceptor_pubkey_hash, lock_time)?;
+            create_challenge_p2wsh_script(&self.public_key, &acceptor_pubkey_hash, lock_time)?;
 
         // Challenger sweep tx is signed by the original secret key
         self.signer.sign_p2wsh_input_challenger(

--- a/crates/transaction-builder/src/transaction_signer.rs
+++ b/crates/transaction-builder/src/transaction_signer.rs
@@ -1,11 +1,12 @@
 use bitcoin::{
     Amount, EcdsaSighashType, Psbt, PublicKey, ScriptBuf, Transaction,
+    absolute::LockTime,
     secp256k1::{self, All, Context, Message, Scalar, SecretKey, Signing},
     sighash::SighashCache,
 };
 use op_rand_types::FirstRankCommitment;
 
-use crate::errors::TransactionError;
+use crate::{errors::TransactionError, scripts::create_challenge_p2wsh_script};
 
 /// `TransactionSigner` handles all transaction signing operations
 #[derive(Debug, Clone)]
@@ -42,22 +43,34 @@ impl<C: Signing> TransactionSigner<C> {
         &self.ctx
     }
 
-    /// Signs a p2wsh input for the acceptor using the OP_IF (immediate) branch
+    /// Signs a P2WSH input for the acceptor using the OP_IF (immediate) branch,
+    /// assuming the witness script verifies the hash160 of the public key before signature.
     pub fn sign_p2wsh_input_acceptor(
         &self,
         tx: &mut Transaction,
         input_index: usize,
         amount: Amount,
-        witness_script: &ScriptBuf,
+        challenger_pubkey: &PublicKey,
         second_rank_commitment: SecretKey,
+        locktime: LockTime,
     ) -> Result<(), TransactionError> {
-        let mut sighash_cache = SighashCache::new(&*tx);
-        let sighash = sighash_cache
-            .p2wsh_signature_hash(input_index, witness_script, amount, EcdsaSighashType::All)
-            .map_err(|_e| TransactionError::FailedToSignP2wshInput)?;
-
         let scalar = Scalar::from(second_rank_commitment);
         let signing_key = self.secret_key.add_tweak(&scalar)?;
+
+        let tweaked_pubkey = signing_key.public_key(&self.ctx);
+        let tweaked_acceptor_pubkey_hash = PublicKey::new(tweaked_pubkey).wpubkey_hash()?;
+
+        let witness_script = create_challenge_p2wsh_script(
+            challenger_pubkey,
+            tweaked_acceptor_pubkey_hash,
+            locktime,
+        )?;
+
+        let mut sighash_cache = SighashCache::new(&*tx);
+        let sighash = sighash_cache
+            .p2wsh_signature_hash(input_index, &witness_script, amount, EcdsaSighashType::All)
+            .map_err(|_e| TransactionError::FailedToSignP2wshInput)?;
+
         let message = Message::from_digest_slice(sighash.as_ref())?;
         let signature = self.ctx.sign_ecdsa(&message, &signing_key);
 
@@ -69,11 +82,12 @@ impl<C: Signing> TransactionSigner<C> {
             .get_mut(input_index)
             .ok_or(TransactionError::InputIndexOutOfBounds)?;
 
-        // Build witness for OP_IF branch: <signature> <1> <witness_script>
+        // Correct witness: <signature> <pubkey_bytes> <1> <witness_script>
         tx_input.witness.clear();
-        tx_input.witness.push(final_signature); // Acceptor's signature with tweaked key
-        tx_input.witness.push(vec![1]); // Push 1 to take OP_IF branch
-        tx_input.witness.push(witness_script.to_bytes()); // The witness script
+        tx_input.witness.push(final_signature);
+        tx_input.witness.push(tweaked_pubkey.serialize());
+        tx_input.witness.push(vec![1]); // Select OP_IF
+        tx_input.witness.push(witness_script.to_bytes());
 
         Ok(())
     }

--- a/crates/transaction-builder/src/transaction_signer.rs
+++ b/crates/transaction-builder/src/transaction_signer.rs
@@ -1,0 +1,222 @@
+use bitcoin::{
+    Amount, EcdsaSighashType, Psbt, PublicKey, ScriptBuf, Transaction,
+    secp256k1::{self, All, Context, Message, Scalar, SecretKey, Signing},
+    sighash::SighashCache,
+};
+use op_rand_types::FirstRankCommitment;
+
+use crate::errors::TransactionError;
+
+/// `TransactionSigner` handles all transaction signing operations
+#[derive(Debug, Clone)]
+pub struct TransactionSigner<C: Context> {
+    secret_key: SecretKey,
+    ctx: secp256k1::Secp256k1<C>,
+}
+
+impl From<SecretKey> for TransactionSigner<All> {
+    fn from(secret_key: SecretKey) -> Self {
+        let ctx = secp256k1::Secp256k1::new();
+        TransactionSigner { secret_key, ctx }
+    }
+}
+
+impl From<&SecretKey> for TransactionSigner<All> {
+    fn from(secret_key: &SecretKey) -> Self {
+        let ctx = secp256k1::Secp256k1::new();
+        TransactionSigner {
+            secret_key: *secret_key,
+            ctx,
+        }
+    }
+}
+
+impl<C: Signing> TransactionSigner<C> {
+    /// Creates a new `TransactionSigner` with the given secret key and context
+    pub fn new(secret_key: SecretKey, ctx: secp256k1::Secp256k1<C>) -> Self {
+        TransactionSigner { secret_key, ctx }
+    }
+
+    /// Returns the context of the `TransactionSigner`
+    pub fn ctx(&self) -> &secp256k1::Secp256k1<C> {
+        &self.ctx
+    }
+
+    /// Signs a p2wsh input for the acceptor using the OP_IF (immediate) branch
+    pub fn sign_p2wsh_input_acceptor(
+        &self,
+        tx: &mut Transaction,
+        input_index: usize,
+        amount: Amount,
+        witness_script: &ScriptBuf,
+        second_rank_commitment: SecretKey,
+    ) -> Result<(), TransactionError> {
+        let mut sighash_cache = SighashCache::new(&*tx);
+        let sighash = sighash_cache
+            .p2wsh_signature_hash(input_index, witness_script, amount, EcdsaSighashType::All)
+            .map_err(|_e| TransactionError::FailedToSignP2wshInput)?;
+
+        let scalar = Scalar::from(second_rank_commitment);
+        let signing_key = self.secret_key.add_tweak(&scalar)?;
+        let message = Message::from_digest_slice(sighash.as_ref())?;
+        let signature = self.ctx.sign_ecdsa(&message, &signing_key);
+
+        let mut final_signature = signature.serialize_der().to_vec();
+        final_signature.push(EcdsaSighashType::All as u8);
+
+        let tx_input = tx
+            .input
+            .get_mut(input_index)
+            .ok_or(TransactionError::InputIndexOutOfBounds)?;
+
+        // Build witness for OP_IF branch: <signature> <1> <witness_script>
+        tx_input.witness.clear();
+        tx_input.witness.push(final_signature); // Acceptor's signature with tweaked key
+        tx_input.witness.push(vec![1]); // Push 1 to take OP_IF branch
+        tx_input.witness.push(witness_script.to_bytes()); // The witness script
+
+        Ok(())
+    }
+
+    /// Signs a p2wsh input for the challenger using the OP_ELSE (delayed) branch
+    pub fn sign_p2wsh_input_challenger(
+        &self,
+        tx: &mut Transaction,
+        input_index: usize,
+        amount: Amount,
+        witness_script: &ScriptBuf,
+    ) -> Result<(), TransactionError> {
+        let mut sighash_cache = SighashCache::new(&*tx);
+        let sighash = sighash_cache
+            .p2wsh_signature_hash(input_index, witness_script, amount, EcdsaSighashType::All)
+            .map_err(|_e| TransactionError::FailedToSignP2wshInput)?;
+
+        let message = Message::from_digest_slice(sighash.as_ref())?;
+        let signature = self.ctx.sign_ecdsa(&message, &self.secret_key);
+
+        let mut final_signature = signature.serialize_der().to_vec();
+        final_signature.push(EcdsaSighashType::All as u8);
+
+        let tx_input = tx
+            .input
+            .get_mut(input_index)
+            .ok_or(TransactionError::InputIndexOutOfBounds)?;
+
+        // Build witness for OP_ELSE branch: <signature> <0> <witness_script>
+        tx_input.witness.clear();
+        tx_input.witness.push(final_signature); // Challenger's signature
+        tx_input.witness.push(vec![]); // Push 0 to take OP_ELSE branch
+        tx_input.witness.push(witness_script.to_bytes()); // The witness script
+
+        Ok(())
+    }
+
+    /// Signs a single input inside `Transaction` by its index
+    pub fn sign_single_input(
+        &self,
+        tx: &mut Transaction,
+        input_index: usize,
+        amount: Amount,
+    ) -> Result<(), TransactionError> {
+        let public_key = self.secret_key.public_key(&self.ctx);
+        let script_code = ScriptBuf::new_p2wpkh(&PublicKey::new(public_key).wpubkey_hash()?);
+
+        let mut sighash_cache = SighashCache::new(&*tx);
+        let sighash = sighash_cache.p2wpkh_signature_hash(
+            input_index,
+            &script_code,
+            amount,
+            EcdsaSighashType::All,
+        )?;
+
+        let tx_input = tx
+            .input
+            .get_mut(input_index)
+            .ok_or(TransactionError::InputIndexOutOfBounds)?;
+
+        let message = Message::from_digest_slice(sighash.as_ref())?;
+        let signature = self.ctx.sign_ecdsa(&message, &self.secret_key);
+
+        let mut final_signature = signature.serialize_der().to_vec();
+        final_signature.push(EcdsaSighashType::All as u8);
+
+        tx_input.witness.clear();
+        tx_input.witness.push(final_signature);
+        tx_input.witness.push(public_key.serialize());
+
+        Ok(())
+    }
+
+    /// Signs a single input inside `Psbt` by its index
+    /// If the secret key is not provided, the original secret key will be used
+    pub fn sign_psbt_input(
+        &self,
+        psbt: &mut Psbt,
+        input_index: usize,
+        amount: Amount,
+        first_rank_commitment: Option<FirstRankCommitment>,
+    ) -> Result<(), TransactionError> {
+        let psbt_input = psbt
+            .inputs
+            .get_mut(input_index)
+            .ok_or(TransactionError::InputIndexOutOfBounds)?;
+
+        let mut secret_key = self.secret_key;
+        if let Some(first_rank_commitment) = first_rank_commitment {
+            secret_key = first_rank_commitment.add_tweak(&self.secret_key)?;
+        }
+
+        let public_key = secret_key.public_key(&self.ctx);
+        let script_pubkey = ScriptBuf::new_p2wpkh(&PublicKey::new(public_key).wpubkey_hash()?);
+
+        let mut sighasher = SighashCache::new(&psbt.unsigned_tx);
+        let sighash = sighasher.p2wpkh_signature_hash(
+            input_index,
+            &script_pubkey,
+            amount,
+            EcdsaSighashType::All,
+        )?;
+
+        let message = Message::from_digest_slice(sighash.as_ref())?;
+        let signature = self.ctx.sign_ecdsa(&message, &secret_key);
+
+        let final_signature = bitcoin::ecdsa::Signature {
+            signature,
+            sighash_type: EcdsaSighashType::All,
+        };
+
+        psbt_input
+            .partial_sigs
+            .insert(PublicKey::new(public_key), final_signature);
+
+        let witness_utxo = bitcoin::TxOut {
+            value: amount,
+            script_pubkey,
+        };
+        psbt_input.witness_utxo = Some(witness_utxo);
+
+        let psbt_sighash_type = bitcoin::psbt::PsbtSighashType::from(EcdsaSighashType::All);
+        if psbt_input.sighash_type.is_none() {
+            psbt_input.sighash_type = Some(psbt_sighash_type);
+        }
+
+        Ok(())
+    }
+
+    /// Signs all transaction inputs with the same secret key
+    pub fn sign_transaction(
+        &self,
+        tx: &mut Transaction,
+        amounts: Vec<Amount>,
+    ) -> Result<(), TransactionError> {
+        if tx.input.len() != amounts.len() {
+            return Err(TransactionError::InputsOutputsLengthMismatch);
+        }
+
+        for (input_index, amount) in amounts.iter().enumerate() {
+            self.sign_single_input(tx, input_index, *amount)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/transaction-builder/src/transaction_signer.rs
+++ b/crates/transaction-builder/src/transaction_signer.rs
@@ -62,7 +62,7 @@ impl<C: Signing> TransactionSigner<C> {
 
         let witness_script = create_challenge_p2wsh_script(
             challenger_pubkey,
-            tweaked_acceptor_pubkey_hash,
+            &tweaked_acceptor_pubkey_hash,
             locktime,
         )?;
 

--- a/crates/transaction-builder/src/validations.rs
+++ b/crates/transaction-builder/src/validations.rs
@@ -1,0 +1,59 @@
+use bitcoin::{
+    Psbt, PublicKey, ScriptBuf, Transaction, WPubkeyHash, absolute::LockTime, hashes::Hash,
+};
+use eyre::ensure;
+
+use crate::scripts::create_challenge_p2wsh_script;
+
+/// Checks that the specified deposit transaction output has a valid locking script:
+/// `hash160(P_C)`, where `P_C` is the pubkey of the challenger combined with one of the
+/// first rank commitments.
+///
+/// Should be called by the acceptor to validate the deposit transaction to make sure it
+/// can be used as a challenge transaction input.
+pub fn validate_deposit_transaction(
+    transaction: &Transaction,
+    challenger_pubkey_hash: &[u8],
+    output_index: usize,
+) -> eyre::Result<()> {
+    let output = transaction.output[output_index].clone();
+    let output_script = output.script_pubkey;
+    let pubkey_hash = WPubkeyHash::from_slice(challenger_pubkey_hash)?;
+    let expected_script = ScriptBuf::new_p2wpkh(&pubkey_hash);
+
+    ensure!(
+        output_script == expected_script,
+        "Output script does not match expected script"
+    );
+
+    Ok(())
+}
+
+/// Checks that the specified PSBT has a valid challenge output. For the the challenger it's
+/// important to check that the output script contains their original pubkey with the specified
+/// locktime.
+///
+/// Should be called by the challenger to validate the PSBT to make sure it contains a valid
+/// challenge output.
+pub fn validate_challenge_psbt(
+    psbt: &Psbt,
+    acceptor_pubkey_hash: WPubkeyHash,
+    challenger_pubkey: PublicKey,
+    locktime: LockTime,
+    output_index: usize,
+) -> eyre::Result<()> {
+    let challenge_script =
+        create_challenge_p2wsh_script(&challenger_pubkey, acceptor_pubkey_hash, locktime)?;
+
+    let output = psbt.unsigned_tx.output[output_index].clone();
+    let output_script = output.script_pubkey;
+
+    let expected_script = ScriptBuf::new_p2wsh(&challenge_script.wscript_hash());
+
+    ensure!(
+        output_script == expected_script,
+        "Output script does not match expected script"
+    );
+
+    Ok(())
+}

--- a/crates/transaction-builder/src/validations.rs
+++ b/crates/transaction-builder/src/validations.rs
@@ -1,6 +1,4 @@
-use bitcoin::{
-    Psbt, PublicKey, ScriptBuf, Transaction, WPubkeyHash, absolute::LockTime, hashes::Hash,
-};
+use bitcoin::{Psbt, PublicKey, ScriptBuf, Transaction, WPubkeyHash, absolute::LockTime};
 use eyre::ensure;
 
 use crate::scripts::create_challenge_p2wsh_script;
@@ -13,13 +11,12 @@ use crate::scripts::create_challenge_p2wsh_script;
 /// can be used as a challenge transaction input.
 pub fn validate_deposit_transaction(
     transaction: &Transaction,
-    challenger_pubkey_hash: &[u8],
+    challenger_pubkey_hash: &WPubkeyHash,
     output_index: usize,
 ) -> eyre::Result<()> {
     let output = transaction.output[output_index].clone();
     let output_script = output.script_pubkey;
-    let pubkey_hash = WPubkeyHash::from_slice(challenger_pubkey_hash)?;
-    let expected_script = ScriptBuf::new_p2wpkh(&pubkey_hash);
+    let expected_script = ScriptBuf::new_p2wpkh(challenger_pubkey_hash);
 
     ensure!(
         output_script == expected_script,
@@ -37,7 +34,7 @@ pub fn validate_deposit_transaction(
 /// challenge output.
 pub fn validate_challenge_psbt(
     psbt: &Psbt,
-    acceptor_pubkey_hash: WPubkeyHash,
+    acceptor_pubkey_hash: &WPubkeyHash,
     challenger_pubkey: PublicKey,
     locktime: LockTime,
     output_index: usize,


### PR DESCRIPTION
Changes
--

- Added validations for deposit and challenge transaction outputs
- Fixed the challenge locking script to contain acceptor public key hash instead of raw public key. It is needed for the challenger to be able to recover the witness script without knowing which commitment was chosen by the acceptor
- Move the signing logic out of the tx builder
- Add SDK notes to README